### PR TITLE
update github action to use stable flutter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
         with:
-          channel: beta
+          channel: stable
       - run: flutter pub get
-      - uses: bluefireteam/flutter-gh-pages@v7
+      - uses: bluefireteam/flutter-gh-pages@v8
         with:
           baseHref: /GreenScout/


### PR DESCRIPTION
For some reason our GitHub action for publishing to GitHub Pages was set to use the `beta` release channel. In the (unreleased) version of the flutter SDK now in beta, a command line option which our action relies on was removed. We need to stick to `stable`, at the very least until the authors of the action address the problem.