### PR TITLE
Re-update GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          flutter-version: 3.27.4
       - run: flutter pub get
       - uses: bluefireteam/flutter-gh-pages@v8
         with:


### PR DESCRIPTION
The target version for `stable` also updated... locking to the version I'm using locally that is known to work.